### PR TITLE
video component

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "react": "^16.8.6",
     "react-apollo": "^2.5.8",
     "react-dom": "^16.8.6",
+    "react-player": "^1.11.2",
     "react-scripts": "3.0.1"
   },
   "scripts": {

--- a/src/Apollo/Queries/getVideo.js
+++ b/src/Apollo/Queries/getVideo.js
@@ -1,0 +1,15 @@
+import { gql } from 'apollo-boost'
+
+const getVideo = gql`
+  query($id: ID!) {
+    video(where: {
+      id: $id
+    }) {
+      id
+      title
+      externalURL 
+    }
+  }
+`
+
+export default getVideo

--- a/src/Apollo/Queries/getVideos.js
+++ b/src/Apollo/Queries/getVideos.js
@@ -1,0 +1,14 @@
+import { gql } from 'apollo-boost'
+
+const getVideo = gql`
+  query {
+    videos {
+      id
+      title
+      description
+      externalURL
+    }
+  }
+`
+
+export default getVideo

--- a/src/Components/Video/Video.js
+++ b/src/Components/Video/Video.js
@@ -1,0 +1,26 @@
+import React from "react";
+import { Query } from "react-apollo";
+import ReactPlayer from "react-player";
+
+import getVideo from "../../Apollo/Queries/getVideo";
+
+const Video = ({ videoId, width, height, style, controls, loop }) => {
+  return (
+    <Query query={getVideo} variables={{ id: videoId }}>
+      {({ data, loading, error }) =>
+        !loading && (
+          <ReactPlayer
+            url={data.video.externalURL}
+            width={width}
+            height={height}
+            style={style}
+            controls={controls}
+            loop={loop}
+          />
+        )
+      }
+    </Query>
+  );
+};
+
+export default Video;

--- a/src/Components/Video/Video.js
+++ b/src/Components/Video/Video.js
@@ -4,6 +4,15 @@ import ReactPlayer from "react-player";
 
 import getVideo from "../../Apollo/Queries/getVideo";
 
+// Only videoId prop is needed
+// Other props will have default values provided by react-player
+
+// Default values:
+// width - 640
+// height - 360
+// controls - false
+// loop - false
+
 const Video = ({ videoId, width, height, style, controls, loop }) => {
   return (
     <Query query={getVideo} variables={{ id: videoId }}>

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,19 @@ import "./index.css";
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
 
-ReactDOM.render(<App />, document.getElementById("root"));
+import ApolloClient from "apollo-boost";
+import { ApolloProvider } from "react-apollo";
+
+const client = new ApolloClient({
+  uri: "https://eu1.prisma.sh/tim-dommett/demo/dev"
+});
+
+ReactDOM.render(
+  <ApolloProvider client={client}>
+    <App />
+  </ApolloProvider>,
+  document.getElementById("root")
+);
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3206,6 +3206,11 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+deepmerge@^3.0.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.3.0.tgz#d3c47fd6f3a93d517b14426b0628a17b0125f5f7"
+  integrity sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==
+
 default-gateway@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-4.2.0.tgz#167104c7500c2115f6dd69b0a536bb8ed720552b"
@@ -5932,6 +5937,11 @@ load-json-file@^4.0.0:
     pify "^3.0.0"
     strip-bom "^3.0.0"
 
+load-script@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
+  integrity sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ=
+
 loader-fs-cache@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/loader-fs-cache/-/loader-fs-cache-1.0.2.tgz#54cedf6b727e1779fd8f01205f05f6e88706f086"
@@ -7743,6 +7753,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier@1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+
 pretty-bytes@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.2.0.tgz#96c92c6e95a0b35059253fb33c03e260d40f5a1f"
@@ -7806,7 +7821,7 @@ prompts@^2.0.1:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.6, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -8039,6 +8054,15 @@ react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
+react-player@^1.11.2:
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/react-player/-/react-player-1.11.2.tgz#fc164f1ca12631887e6b46eee5462b5709f102da"
+  integrity sha512-VOO+3np/4DBy6A6NYxDUSvfigo2mkBqwQgpKgyNSq46Ew2XA6f+K26DWs0KLxtkLRbm2tcPrQMRqek8hh21ipg==
+  dependencies:
+    deepmerge "^3.0.0"
+    load-script "^1.0.0"
+    prop-types "^15.5.6"
 
 react-scripts@3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Wrapped the root App with ApolloProvider pointing towards `https://eu1.prisma.sh/tim-dommett/demo/dev`

Created two queries in `src/Apollo/Queries`. `getVideos to get the entire list of videos and `getVideo` that returns data for one video when provided an ID.

The Video component itself only requires the `videoId` prop as all other props have default values provided by `react-player`.